### PR TITLE
:bug: Fix keymaps for moving buffer

### DIFF
--- a/dotfiles/.config/nvim/lua/user/mappings.lua
+++ b/dotfiles/.config/nvim/lua/user/mappings.lua
@@ -1,6 +1,16 @@
 return {
   n = {
-    ["L"] = { "<cmd>bnext<cr>", desc = "Next Buffer" },
-    ["H"] = { "<cmd>bprevious<cr>", desc = "Previous Buffer" },
+    ["L"] = {
+      function()
+        require("astronvim.utils.buffer").nav(vim.v.count > 0 and vim.v.count or 1)
+      end,
+      desc = "Next buffer",
+    },
+    ["H"] = {
+      function()
+        require("astronvim.utils.buffer").nav(-(vim.v.count > 0 and vim.v.count or 1))
+      end,
+      desc = "Previous buffer",
+    },
   },
 }


### PR DESCRIPTION
Fix to use keymap settings of astronvim (`]b`, `[b`)  for moving by `H` and `L`